### PR TITLE
chore: scaffold x448_dart package (MIT) with CI

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,17 @@
+name: Dart CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+      - run: dart --version
+      - run: dart pub get
+      - run: dart format --output=none --set-exit-if-changed .
+      - run: dart analyze
+      - run: dart test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # x448_dart
-X448 (RFC 7748) Elliptic-Curve Diffie–Hellman key exchange for Dart and Flutter. Provides secure key generation, public key derivation, and shared secret computation, with optional FlutterFlow-friendly base64 helpers.
+
+X448 (RFC 7748) Elliptic-Curve Diffie–Hellman for Dart & Flutter.
+Secure key generation, public key derivation, and shared secret computation, with FlutterFlow-friendly base64 helpers.
+
+Status: includes a pure Dart backend; RFC test vectors to be added next.
+

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,9 @@
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    - always_declare_return_types
+    - avoid_print
+    - directives_ordering
+    - prefer_final_locals
+    - unawaited_futures

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,0 +1,13 @@
+import 'dart:convert';
+import 'package:x448_dart/x448.dart';
+
+Future<void> main() async {
+  final alice = await X448.generate();
+  final bob = await X448.generate();
+  final s1 =
+      X448.sharedSecret(privateKey: alice.privateKey, peerPublicKey: bob.publicKey);
+  final s2 =
+      X448.sharedSecret(privateKey: bob.privateKey, peerPublicKey: alice.publicKey);
+  print('equal? ${base64Encode(s1) == base64Encode(s2)}');
+}
+

--- a/lib/flutterflow_x448.dart
+++ b/lib/flutterflow_x448.dart
@@ -1,0 +1,21 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'x448.dart';
+
+Future<String> x448GeneratePrivateKeyB64() async {
+  final kp = await X448.generate();
+  return base64Encode(kp.privateKey);
+}
+
+Future<String> x448PublicKeyFromPrivateB64(String privB64) async {
+  final priv = Uint8List.fromList(base64Decode(privB64));
+  final pub = X448.publicKey(priv);
+  return base64Encode(pub);
+}
+
+Future<String> x448SharedSecretB64(String myPrivB64, String peerPubB64) async {
+  final priv = Uint8List.fromList(base64Decode(myPrivB64));
+  final pub = Uint8List.fromList(base64Decode(peerPubB64));
+  final ss = X448.sharedSecret(privateKey: priv, peerPublicKey: pub);
+  return base64Encode(ss);
+}

--- a/lib/src/backend_pure.dart
+++ b/lib/src/backend_pure.dart
@@ -1,0 +1,150 @@
+// lib/src/backend_pure.dart
+import 'dart:typed_data';
+import 'utils.dart';
+
+/// Prime p = 2^448 - 2^224 - 1  (Curve448 / RFC 7748)
+final BigInt _p = (BigInt.one << 448) - (BigInt.one << 224) - BigInt.one;
+
+const int _bytes = 56; // 56-byte field elements/scalars
+const int _a24 = 39081; // (A + 2) / 4 for Curve448
+
+// ---- helpers ----
+
+BigInt _mod(BigInt x) {
+  x %= _p;
+  return x.isNegative ? x + _p : x;
+}
+
+BigInt _fromLE(Uint8List b) {
+  BigInt x = BigInt.zero;
+  for (int i = b.length - 1; i >= 0; i--) {
+    x = (x << BigInt.from(8)) | BigInt.from(b[i]);
+  }
+  return x;
+}
+
+Uint8List _toLE(BigInt x, int len) {
+  x = _mod(x);
+  final out = Uint8List(len);
+  for (int i = 0; i < len; i++) {
+    out[i] = (x & BigInt.from(0xff)).toInt();
+    x >>= 8;
+  }
+  return out;
+}
+
+BigInt _powMod(BigInt a, BigInt e) {
+  a = _mod(a);
+  BigInt r = BigInt.one;
+  while (e > BigInt.zero) {
+    if ((e & BigInt.one) == BigInt.one) r = _mod(r * a);
+    a = _mod(a * a);
+    e >>= 1;
+  }
+  return r;
+}
+
+/// Clamp per RFC 7748 (X448): k[0] &= 0xFC; k[55] |= 0x80;
+Uint8List _clamp(Uint8List k) {
+  if (k.length != _bytes) throw ArgumentError('X448 scalar must be 56 bytes');
+  final out = Uint8List.fromList(k);
+  clampX448(out); // from utils.dart
+  return out;
+}
+
+// ---- core X448 ladder ----
+
+Uint8List _x448(Uint8List scalar, Uint8List uBytes) {
+  if (scalar.length != _bytes || uBytes.length != _bytes) {
+    throw ArgumentError('X448 expects 56-byte inputs');
+  }
+  final k = _clamp(scalar);
+  final x1 = _fromLE(uBytes);
+
+  BigInt x2 = BigInt.one;
+  BigInt z2 = BigInt.zero;
+  BigInt x3 = _mod(x1);
+  BigInt z3 = BigInt.one;
+  int swap = 0;
+
+  for (int t = 447; t >= 0; t--) {
+    final bit = (k[t >> 3] >> (t & 7)) & 1;
+    swap ^= bit;
+    if (swap == 1) {
+      // cswap(x2,z2) <-> (x3,z3)
+      final tx = x2;
+      x2 = x3;
+      x3 = tx;
+      final tz = z2;
+      z2 = z3;
+      z3 = tz;
+    }
+    swap = bit;
+
+    final A = _mod(x2 + z2);
+    final B = _mod(x2 - z2);
+    final AA = _mod(A * A);
+    final BB = _mod(B * B);
+    final E = _mod(AA - BB);
+
+    final C = _mod(x3 + z3);
+    final D = _mod(x3 - z3);
+    final DA = _mod(D * A);
+    final CB = _mod(C * B);
+
+    x3 = _mod((DA + CB) * (DA + CB));
+    z3 = _mod(_mod(x1) * (DA - CB) * (DA - CB));
+    x2 = _mod(AA * BB);
+    z2 = _mod(E * (_mod(BB + (BigInt.from(_a24) * E))));
+  }
+
+  if (swap == 1) {
+    final tx = x2;
+    x2 = x3;
+    x3 = tx;
+    final tz = z2;
+    z2 = z3;
+    z3 = tz;
+  }
+
+  final z2Inv = _powMod(z2, _p - BigInt.two); // inverse via Fermat
+  final x = _mod(x2 * z2Inv);
+  return _toLE(x, _bytes);
+}
+
+bool _isAllZero(Uint8List b) {
+  int acc = 0;
+  for (var v in b) acc |= v;
+  return acc == 0;
+}
+
+// ---- public backend API (used by lib/x448.dart) ----
+
+Future<Uint8List> backendGeneratePrivateKey() async {
+  final k = randomBytes(_bytes);
+  clampX448(k);
+  return k;
+}
+
+Uint8List backendPublicKey(Uint8List privateKey) {
+  if (privateKey.length != _bytes) {
+    throw ArgumentError('X448 private key must be 56 bytes');
+  }
+  // Base point u = 5 → 56-byte little-endian
+  final baseU = Uint8List(_bytes)..[0] = 5;
+  return _x448(privateKey, baseU);
+}
+
+Uint8List backendSharedSecret({
+  required Uint8List privateKey,
+  required Uint8List peerPublicKey,
+}) {
+  if (privateKey.length != _bytes || peerPublicKey.length != _bytes) {
+    throw ArgumentError('X448 inputs must be 56 bytes');
+  }
+  final ss = _x448(privateKey, peerPublicKey);
+  if (_isAllZero(ss)) {
+    throw StateError('X448 invalid shared secret (all zeros)');
+  }
+  return ss;
+}

--- a/lib/src/backend_stub.dart
+++ b/lib/src/backend_stub.dart
@@ -1,0 +1,14 @@
+import 'dart:typed_data';
+
+Future<Uint8List> backendGeneratePrivateKey() async =>
+    throw UnimplementedError('X448 backend not implemented yet.');
+
+Uint8List backendPublicKey(Uint8List privateKey) =>
+    throw UnimplementedError('X448 backend not implemented yet.');
+
+Uint8List backendSharedSecret({
+  required Uint8List privateKey,
+  required Uint8List peerPublicKey,
+}) =>
+    throw UnimplementedError('X448 backend not implemented yet.');
+

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+Uint8List randomBytes(int n) {
+  final rng = Random.secure();
+  final b = Uint8List(n);
+  for (var i = 0; i < n; i++) {
+    b[i] = rng.nextInt(256);
+  }
+  return b;
+}
+
+/// RFC 7748 X448 clamping: k[0] &= 0xFC; k[55] |= 0x80;
+void clampX448(Uint8List k) {
+  if (k.length != 56) {
+    throw ArgumentError('X448 private key must be 56 bytes');
+  }
+  k[0] &= 0xFC;
+  k[55] |= 0x80;
+}
+
+void zeroize(Uint8List b) {
+  for (var i = 0; i < b.length; i++) {
+    b[i] = 0;
+  }
+}
+
+String b64(Uint8List b) => base64Encode(b);
+Uint8List deb64(String s) => Uint8List.fromList(base64Decode(s));
+
+String hex(Uint8List b) =>
+    b.map((x) => x.toRadixString(16).padLeft(2, '0')).join();
+Uint8List dehex(String s) {
+  final out = Uint8List(s.length ~/ 2);
+  for (var i = 0; i < out.length; i++) {
+    out[i] = int.parse(s.substring(2 * i, 2 * i + 2), radix: 16);
+  }
+  return out;
+}

--- a/lib/x448.dart
+++ b/lib/x448.dart
@@ -1,0 +1,36 @@
+library x448_dart;
+
+import 'dart:typed_data';
+
+// Choose the backend: pure Dart everywhere for now.
+import 'src/backend_pure.dart';
+
+/// 56-byte little-endian scalars and u-coordinates.
+class X448KeyPair {
+  final Uint8List privateKey; // 56 bytes
+  final Uint8List publicKey; // 56 bytes
+  const X448KeyPair(this.privateKey, this.publicKey);
+}
+
+abstract class X448 {
+  /// Generate a random private key (56 bytes), clamp, and derive public key.
+  static Future<X448KeyPair> generate() async {
+    final priv = await backendGeneratePrivateKey();
+    final pub = backendPublicKey(priv);
+    return X448KeyPair(priv, pub);
+  }
+
+  /// Derive public key from a clamped private key (56 bytes).
+  static Uint8List publicKey(Uint8List privateKey) =>
+      backendPublicKey(privateKey);
+
+  /// Compute shared secret X448(k, peerU) → 56 bytes (raw). NOT a KDF.
+  static Uint8List sharedSecret({
+    required Uint8List privateKey,
+    required Uint8List peerPublicKey,
+  }) =>
+      backendSharedSecret(
+        privateKey: privateKey,
+        peerPublicKey: peerPublicKey,
+      );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,24 @@
+name: x448_dart
+description: X448 (RFC 7748) Elliptic-Curve Diffie–Hellman for Dart/Flutter with FlutterFlow-friendly base64 helpers.
+version: 0.0.1
+repository: https://github.com/Dom-Cogan/x448_dart
+issue_tracker: https://github.com/Dom-Cogan/x448_dart/issues
+homepage: https://pub.dev/packages/x448_dart
+
+environment:
+  sdk: ">=3.4.0 <4.0.0"
+
+platforms:
+  android:
+  ios:
+  macos:
+  windows:
+  linux:
+  web:
+
+dependencies:
+  meta: ^1.11.0
+
+dev_dependencies:
+  lints: ^3.0.0
+  test: ^1.25.0

--- a/test/x448_smoke_test.dart
+++ b/test/x448_smoke_test.dart
@@ -1,0 +1,22 @@
+import 'package:test/test.dart';
+import 'package:x448_dart/x448.dart';
+
+void main() {
+  test('ECDH round-trip: Alice/Bob derive same secret', () async {
+    final a = await X448.generate();
+    final b = await X448.generate();
+
+    final s1 = X448.sharedSecret(
+      privateKey: a.privateKey,
+      peerPublicKey: b.publicKey,
+    );
+    final s2 = X448.sharedSecret(
+      privateKey: b.privateKey,
+      peerPublicKey: a.publicKey,
+    );
+
+    expect(s1.length, 56);
+    expect(s2.length, 56);
+    expect(s1, equals(s2));
+  });
+}

--- a/test/x448_vectors_test.dart
+++ b/test/x448_vectors_test.dart
@@ -1,0 +1,8 @@
+import 'package:test/test.dart';
+
+void main() {
+  test('X448 known vectors (TODO)', () {
+    // TODO: Add RFC 7748 §5.2 test vectors and verify public/shared outputs.
+    expect(true, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- implement a pure Dart backend for X448 key generation and ECDH
- add smoke test and example demonstrating shared-secret round-trip
- re-enable formatting checks in CI and update README status
- apply dartfmt-style formatting across backend, utils, API, and tests

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68975d7c3360833282fcec183d138bcd