### PR TITLE
Add pure Dart X448 backend and smoke test

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -1,3 +1,10 @@
-void main() {
-  print('X448 example – backend not yet implemented.');
+import 'dart:convert';
+import 'package:x448_dart/x448.dart';
+
+Future<void> main() async {
+  final alice = await X448.generate();
+  final bob   = await X448.generate();
+  final s1 = X448.sharedSecret(privateKey: alice.privateKey, peerPublicKey: bob.publicKey);
+  final s2 = X448.sharedSecret(privateKey: bob.privateKey,   peerPublicKey: alice.publicKey);
+  print('equal? ${base64Encode(s1) == base64Encode(s2)}');
 }

--- a/example/main.dart
+++ b/example/main.dart
@@ -6,5 +6,6 @@ Future<void> main() async {
   final bob   = await X448.generate();
   final s1 = X448.sharedSecret(privateKey: alice.privateKey, peerPublicKey: bob.publicKey);
   final s2 = X448.sharedSecret(privateKey: bob.privateKey,   peerPublicKey: alice.publicKey);
+  // ignore: avoid_print
   print('equal? ${base64Encode(s1) == base64Encode(s2)}');
 }

--- a/lib/src/backend_pure.dart
+++ b/lib/src/backend_pure.dart
@@ -18,7 +18,7 @@ BigInt _mod(BigInt x) {
 BigInt _fromLE(Uint8List b) {
   BigInt x = BigInt.zero;
   for (int i = b.length - 1; i >= 0; i--) {
-    x = (x << BigInt.from(8)) | BigInt.from(b[i]);
+    x = (x << 8) | BigInt.from(b[i]);
   }
   return x;
 }
@@ -77,21 +77,21 @@ Uint8List _x448(Uint8List scalar, Uint8List uBytes) {
     }
     swap = bit;
 
-    final A  = _mod(x2 + z2);
-    final B  = _mod(x2 - z2);
-    final AA = _mod(A * A);
-    final BB = _mod(B * B);
-    final E  = _mod(AA - BB);
+    final a  = _mod(x2 + z2);
+    final b  = _mod(x2 - z2);
+    final aa = _mod(a * a);
+    final bb = _mod(b * b);
+    final e  = _mod(aa - bb);
 
-    final C  = _mod(x3 + z3);
-    final D  = _mod(x3 - z3);
-    final DA = _mod(D * A);
-    final CB = _mod(C * B);
+    final c  = _mod(x3 + z3);
+    final d  = _mod(x3 - z3);
+    final da = _mod(d * a);
+    final cb = _mod(c * b);
 
-    x3 = _mod((DA + CB) * (DA + CB));
-    z3 = _mod(_mod(x1) * (DA - CB) * (DA - CB));
-    x2 = _mod(AA * BB);
-    z2 = _mod(E * (_mod(BB + (BigInt.from(_a24) * E))));
+    x3 = _mod((da + cb) * (da + cb));
+    z3 = _mod(_mod(x1) * (da - cb) * (da - cb));
+    x2 = _mod(aa * bb);
+    z2 = _mod(e * (_mod(bb + (BigInt.from(_a24) * e))));
   }
 
   if (swap == 1) {
@@ -106,7 +106,9 @@ Uint8List _x448(Uint8List scalar, Uint8List uBytes) {
 
 bool _isAllZero(Uint8List b) {
   int acc = 0;
-  for (var v in b) acc |= v;
+  for (var v in b) {
+    acc |= v;
+  }
   return acc == 0;
 }
 

--- a/lib/src/backend_pure.dart
+++ b/lib/src/backend_pure.dart
@@ -1,0 +1,142 @@
+// lib/src/backend_pure.dart
+import 'dart:typed_data';
+import 'utils.dart';
+
+/// Prime p = 2^448 - 2^224 - 1  (Curve448 / RFC 7748)
+final BigInt _p = (BigInt.one << 448) - (BigInt.one << 224) - BigInt.one;
+
+const int _bytes = 56;       // 56-byte field elements/scalars
+const int _a24 = 39081;      // (A + 2) / 4 for Curve448
+
+// ---- helpers ----
+
+BigInt _mod(BigInt x) {
+  x %= _p;
+  return x.isNegative ? x + _p : x;
+}
+
+BigInt _fromLE(Uint8List b) {
+  BigInt x = BigInt.zero;
+  for (int i = b.length - 1; i >= 0; i--) {
+    x = (x << BigInt.from(8)) | BigInt.from(b[i]);
+  }
+  return x;
+}
+
+Uint8List _toLE(BigInt x, int len) {
+  x = _mod(x);
+  final out = Uint8List(len);
+  for (int i = 0; i < len; i++) {
+    out[i] = (x & BigInt.from(0xff)).toInt();
+    x >>= 8;
+  }
+  return out;
+}
+
+BigInt _powMod(BigInt a, BigInt e) {
+  a = _mod(a);
+  BigInt r = BigInt.one;
+  while (e > BigInt.zero) {
+    if ((e & BigInt.one) == BigInt.one) r = _mod(r * a);
+    a = _mod(a * a);
+    e >>= 1;
+  }
+  return r;
+}
+
+/// Clamp per RFC 7748 (X448): k[0] &= 0xFC; k[55] |= 0x80;
+Uint8List _clamp(Uint8List k) {
+  if (k.length != _bytes) throw ArgumentError('X448 scalar must be 56 bytes');
+  final out = Uint8List.fromList(k);
+  clampX448(out); // from utils.dart
+  return out;
+}
+
+// ---- core X448 ladder ----
+
+Uint8List _x448(Uint8List scalar, Uint8List uBytes) {
+  if (scalar.length != _bytes || uBytes.length != _bytes) {
+    throw ArgumentError('X448 expects 56-byte inputs');
+  }
+  final k = _clamp(scalar);
+  final x1 = _fromLE(uBytes);
+
+  BigInt x2 = BigInt.one;
+  BigInt z2 = BigInt.zero;
+  BigInt x3 = _mod(x1);
+  BigInt z3 = BigInt.one;
+  int swap = 0;
+
+  for (int t = 447; t >= 0; t--) {
+    final bit = (k[t >> 3] >> (t & 7)) & 1;
+    swap ^= bit;
+    if (swap == 1) {
+      // cswap(x2,z2) <-> (x3,z3)
+      final tx = x2; x2 = x3; x3 = tx;
+      final tz = z2; z2 = z3; z3 = tz;
+    }
+    swap = bit;
+
+    final A  = _mod(x2 + z2);
+    final B  = _mod(x2 - z2);
+    final AA = _mod(A * A);
+    final BB = _mod(B * B);
+    final E  = _mod(AA - BB);
+
+    final C  = _mod(x3 + z3);
+    final D  = _mod(x3 - z3);
+    final DA = _mod(D * A);
+    final CB = _mod(C * B);
+
+    x3 = _mod((DA + CB) * (DA + CB));
+    z3 = _mod(_mod(x1) * (DA - CB) * (DA - CB));
+    x2 = _mod(AA * BB);
+    z2 = _mod(E * (_mod(BB + (BigInt.from(_a24) * E))));
+  }
+
+  if (swap == 1) {
+    final tx = x2; x2 = x3; x3 = tx;
+    final tz = z2; z2 = z3; z3 = tz;
+  }
+
+  final z2Inv = _powMod(z2, _p - BigInt.two); // inverse via Fermat
+  final x = _mod(x2 * z2Inv);
+  return _toLE(x, _bytes);
+}
+
+bool _isAllZero(Uint8List b) {
+  int acc = 0;
+  for (var v in b) acc |= v;
+  return acc == 0;
+}
+
+// ---- public backend API (used by lib/x448.dart) ----
+
+Future<Uint8List> backendGeneratePrivateKey() async {
+  final k = randomBytes(_bytes);
+  clampX448(k);
+  return k;
+}
+
+Uint8List backendPublicKey(Uint8List privateKey) {
+  if (privateKey.length != _bytes) {
+    throw ArgumentError('X448 private key must be 56 bytes');
+  }
+  // Base point u = 5 → 56-byte little-endian
+  final baseU = Uint8List(_bytes)..[0] = 5;
+  return _x448(privateKey, baseU);
+}
+
+Uint8List backendSharedSecret({
+  required Uint8List privateKey,
+  required Uint8List peerPublicKey,
+}) {
+  if (privateKey.length != _bytes || peerPublicKey.length != _bytes) {
+    throw ArgumentError('X448 inputs must be 56 bytes');
+  }
+  final ss = _x448(privateKey, peerPublicKey);
+  if (_isAllZero(ss)) {
+    throw StateError('X448 invalid shared secret (all zeros)');
+  }
+  return ss;
+}

--- a/lib/src/backend_stub.dart
+++ b/lib/src/backend_stub.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 
-/// These stubs deliberately throw. We'll replace them with a pure Dart backend.
-Future<Never> backendGenerate() async =>
+Future<Uint8List> backendGeneratePrivateKey() async =>
     throw UnimplementedError('X448 backend not implemented yet.');
 
 Uint8List backendPublicKey(Uint8List privateKey) =>

--- a/lib/x448.dart
+++ b/lib/x448.dart
@@ -1,7 +1,9 @@
 library x448_dart;
 
 import 'dart:typed_data';
-import 'src/backend_stub.dart';
+
+// Choose the backend: pure Dart everywhere for now.
+import 'src/backend_pure.dart';
 
 /// 56-byte little-endian scalars and u-coordinates.
 class X448KeyPair {
@@ -12,14 +14,20 @@ class X448KeyPair {
 
 abstract class X448 {
   /// Generate a random private key (56 bytes), clamp, and derive public key.
-  static Future<X448KeyPair> generate() => backendGenerate();
+  static Future<X448KeyPair> generate() async {
+    final priv = await backendGeneratePrivateKey();
+    final pub = backendPublicKey(priv);
+    return X448KeyPair(priv, pub);
+  }
 
   /// Derive public key from a clamped private key (56 bytes).
-  static Uint8List publicKey(Uint8List privateKey) => backendPublicKey(privateKey);
+  static Uint8List publicKey(Uint8List privateKey) =>
+      backendPublicKey(privateKey);
 
   /// Compute shared secret X448(k, peerU) → 56 bytes (raw). NOT a KDF.
   static Uint8List sharedSecret({
     required Uint8List privateKey,
     required Uint8List peerPublicKey,
-  }) => backendSharedSecret(privateKey: privateKey, peerPublicKey: peerPublicKey);
+  }) =>
+      backendSharedSecret(privateKey: privateKey, peerPublicKey: peerPublicKey);
 }

--- a/test/x448_smoke_test.dart
+++ b/test/x448_smoke_test.dart
@@ -1,0 +1,16 @@
+import 'package:test/test.dart';
+import 'package:x448_dart/x448.dart';
+
+void main() {
+  test('ECDH round-trip: Alice/Bob derive same secret', () async {
+    final a = await X448.generate();
+    final b = await X448.generate();
+
+    final s1 = X448.sharedSecret(privateKey: a.privateKey, peerPublicKey: b.publicKey);
+    final s2 = X448.sharedSecret(privateKey: b.privateKey, peerPublicKey: a.publicKey);
+
+    expect(s1.length, 56);
+    expect(s2.length, 56);
+    expect(s1, equals(s2));
+  });
+}


### PR DESCRIPTION
## Summary
- implement pure Dart BigInt backend for X448 key generation, public key derivation, and shared secret
- wire library to use pure backend and expose raw byte operations
- add example and smoke test for ECDH round trip

## Testing
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6897719b2cc483329d6df3c59e9a40c1