### PR TITLE
fix(ci): specify boringssl submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/boringssl"]
+	path = third_party/boringssl
+	url = https://github.com/google/boringssl.git


### PR DESCRIPTION
## Summary
- declare boringssl submodule location so git can fetch it during CI

## Testing
- `dart pub get` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6898ce440fa883328c6642b94a81daca